### PR TITLE
[MLIR] Add concatenateOp lowering from lmhlo to Affine.

### DIFF
--- a/tests/lhlo-legalize-to-affine.mlir
+++ b/tests/lhlo-legalize-to-affine.mlir
@@ -202,3 +202,28 @@ func @int_dot_op(%lhs: memref<7x3xi32>, %rhs:
     (memref<7x3xi32>, memref<3x4xi32>, memref<7x4xi32>) -> ()
   return
 }
+
+// CHECK-LABEL: func @concatenate
+func @concatenate(%arg0: memref<1x1xf32>, %arg1: memref<1x100xf32>, %arg2: memref<1x200xf32>, %arg3: memref<1x301xf32>) {
+    // CHECK-NEXT:    %[[RESULT]] = alloc() : memref<1x301xf32>
+    // CHECK-NEXT:    affine.for %[[X:.*]] = 0 to 1 {
+    // CHECK-NEXT:      affine.for %[[Y:.*]] = 0 to 1 {
+    // CHECK-NEXT:        %[[LOAD:.*]] = affine.load %arg0[%[[X]], %[[Y]]] : memref<1x1xf32>
+    // CHECK-NEXT:        affine.store %[[LOAD]], %[[RESULT]][%[[X]], %[[Y]]] : memref<1x301xf32>
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:    affine.for %[[X:.*]] = 0 to 1 {
+    // CHECK-NEXT:      affine.for %[[Y:.*]] = 1 to 101 {
+    // CHECK-NEXT:        %[[LOAD:.*]] = affine.load %arg1[%[[X]], %[[Y]] - 1] : memref<1x100xf32>
+    // CHECK-NEXT:        affine.store %[[LOAD]], %[[RESULT]][%[[X]], %[[Y]]] : memref<1x301xf32>
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:    affine.for %[[X:.*]] = 0 to 1 {
+    // CHECK-NEXT:      affine.for %[[Y:.*]] = 101 to 301 {
+    // CHECK-NEXT:        %[[LOAD:.*]] = affine.load %arg2[%[[X]], %[[Y]] - 101] : memref<1x200xf32>
+    // CHECK-NEXT:        affine.store %[[LOAD]], %[[RESULT]][%[[X]], %[[Y]]] : memref<1x301xf32>
+    %0 = alloc() : memref<1x301xf32>
+    "lmhlo.concatenate"(%arg0, %arg1, %arg2, %0) {dimension = 1 : i64} : (memref<1x1xf32>, memref<1x100xf32>, memref<1x200xf32>, memref<1x301xf32>) -> ()
+    "lmhlo.copy"(%0, %arg3) : (memref<1x301xf32>, memref<1x301xf32>) -> ()
+    "lmhlo.terminator"() : () -> ()
+}


### PR DESCRIPTION
Lowering of `concatenateOp` is added from lmhlo to Affine. The lowering
has been added as a part of `lhlo-legalize-to-affine` pass.

Signed-off-by: Prashant Kumar <prashantk@polymagelabs.com>