### PR TITLE
Should use `CMAKE_CURRENT_*_DIR`

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,3 @@
-include_directories(${PROJECT_SOURCE_DIR}/runtime)
-include_directories(${PROJECT_BINARY_DIR}/runtime)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory(ral)


### PR DESCRIPTION
or it will fail when build mhlo as a llvm external project