### PR TITLE
add BatchNormTraining and BatchNormGrad support in hlo-legalize-to-lhlo

### DIFF
--- a/include/mlir-hlo/Dialect/mhlo/transforms/map_hlo_to_lhlo_op.h
+++ b/include/mlir-hlo/Dialect/mhlo/transforms/map_hlo_to_lhlo_op.h
@@ -41,6 +41,8 @@ MAP_HLO_TO_LHLO(AbsOp);
 MAP_HLO_TO_LHLO(AddOp);
 MAP_HLO_TO_LHLO(AndOp);
 MAP_HLO_TO_LHLO(Atan2Op);
+MAP_HLO_TO_LHLO(BatchNormGradOp);
+MAP_HLO_TO_LHLO(BatchNormTrainingOp);
 MAP_HLO_TO_LHLO(BitcastConvertOp);
 MAP_HLO_TO_LHLO(BroadcastInDimOp);
 MAP_HLO_TO_LHLO(CeilOp);

--- a/lib/Dialect/mhlo/transforms/hlo_legalize_to_lhlo.cc
+++ b/lib/Dialect/mhlo/transforms/hlo_legalize_to_lhlo.cc
@@ -139,8 +139,7 @@ LogicalResult ConvertResults(Operation* op, SmallVectorImpl<Value>& results,
 
   if (op->getNumResults() == 1 && op->getResult(0).getType().isa<TupleType>()) {
     SmallVector<Type, 4> fattenedTypes;
-    op->getResult(0).getType().dyn_cast<TupleType>().getFlattenedTypes(fattenedTypes);
-
+    op->getResult(0).getType().cast<TupleType>().getFlattenedTypes(fattenedTypes);
     for (auto result : llvm::enumerate(fattenedTypes)) {
       if (failed(convert_result(result.value(), result.index()))) return failure();
     }
@@ -149,7 +148,6 @@ LogicalResult ConvertResults(Operation* op, SmallVectorImpl<Value>& results,
       if (failed(convert_result(result.value().getType(), result.index()))) return failure();
     }
   }
-
   return success();
 }
 

--- a/lib/Dialect/mhlo/transforms/hlo_legalize_to_lhlo.cc
+++ b/lib/Dialect/mhlo/transforms/hlo_legalize_to_lhlo.cc
@@ -52,19 +52,19 @@ namespace {
 template <typename T>
 using BaseOpConversion = OpConversionPattern<T>;
 
-Value InsertDynamicAlloc(Location loc, Value result, Value shape_operand,
+Value InsertDynamicAlloc(Location loc, Type result_type, Operation* def_op, Value shape_operand,
                          ConversionPatternRewriter* rewriter) {
-  auto result_type = result.getType().dyn_cast<RankedTensorType>();
-  if (!result_type) {
-    result.getDefiningOp()->emitOpError()
+  auto result_tensor_type = result_type.dyn_cast<RankedTensorType>();
+  if (!result_tensor_type) {
+    def_op->emitOpError()
         << "tensor to buffer conversion expects ranked results";
   }
   auto memref_type =
-      MemRefType::get(result_type.getShape(), result_type.getElementType());
+      MemRefType::get(result_tensor_type.getShape(), result_tensor_type.getElementType());
 
   // Extract the required element out of the vector.
   SmallVector<Value, 4> dynamic_operands;
-  for (auto shape_element : llvm::enumerate(result_type.getShape())) {
+  for (auto shape_element : llvm::enumerate(result_tensor_type.getShape())) {
     if (shape_element.value() != ShapedType::kDynamicSize) continue;
     Value index =
         rewriter->create<arith::ConstantIndexOp>(loc, shape_element.index());
@@ -80,17 +80,17 @@ Value InsertDynamicAlloc(Location loc, Value result, Value shape_operand,
   return rewriter->create<memref::AllocOp>(loc, memref_type, dynamic_operands);
 }
 
-Value InsertAlloc(Location loc, OpResult result,
+Value InsertAlloc(Location loc, Type result_type, Operation* def_op,
                   ConversionPatternRewriter* rewriter) {
-  auto result_type = result.getType().dyn_cast<RankedTensorType>();
-  if (!result_type || !result_type.hasStaticShape()) {
-    result.getDefiningOp()->emitOpError()
+  auto result_tensor_type = result_type.dyn_cast<RankedTensorType>();
+  if (!result_tensor_type || !result_tensor_type.hasStaticShape()) {
+    def_op->emitOpError()
         << "tensor to buffer conversion expects statically shaped results";
   }
   auto memref_type =
-      MemRefType::get(result_type.getShape(), result_type.getElementType());
+      MemRefType::get(result_tensor_type.getShape(), result_tensor_type.getElementType());
   OpBuilder::InsertionGuard guard(*rewriter);
-  rewriter->setInsertionPoint(result.getDefiningOp());
+  rewriter->setInsertionPoint(def_op);
   auto alloc = rewriter->create<memref::AllocOp>(loc, memref_type);
   return alloc;
 }
@@ -101,14 +101,16 @@ LogicalResult ConvertResults(Operation* op, SmallVectorImpl<Value>& results,
                              ConversionPatternRewriter& rewriter) {
   size_t num_operands = results.size();
   SmallVector<Value, 2> tensor_operands;
-  for (auto result : llvm::enumerate(op->getResults())) {
+
+  auto convert_result = [&](Type result_ty, size_t index) {
     RankedTensorType resultType =
-        result.value().getType().dyn_cast<RankedTensorType>();
+      result_ty.dyn_cast<RankedTensorType>();
+
     if (!resultType) return failure();
 
     if (resultType.hasStaticShape()) {
-      results.push_back(InsertAlloc(op->getLoc(), result.value(), &rewriter));
-      continue;
+      results.push_back(InsertAlloc(op->getLoc(), resultType, op, &rewriter));
+      return success();
     }
     auto shape_type_op = dyn_cast<InferShapedTypeOpInterface>(op);
     if (!shape_type_op) return failure();
@@ -118,21 +120,36 @@ LogicalResult ConvertResults(Operation* op, SmallVectorImpl<Value>& results,
         auto operand_type = operand.getType().dyn_cast<MemRefType>();
         if (!operand_type) return failure();
         tensor_operands.push_back(rewriter.create<memref::TensorLoadOp>(
-            op->getLoc(),
-            RankedTensorType::get(operand_type.getShape(),
-                                  operand_type.getElementType()),
-            operand));
+          op->getLoc(),
+          RankedTensorType::get(operand_type.getShape(),
+            operand_type.getElementType()),
+          operand));
       }
     }
 
     SmallVector<Value, 1> results_shape;
     auto status = shape_type_op.reifyReturnTypeShapes(rewriter, tensor_operands,
-                                                      results_shape);
+      results_shape);
     if (failed(status)) return failure();
-    results.push_back(InsertDynamicAlloc(op->getLoc(), result.value(),
-                                         results_shape[result.index()],
-                                         &rewriter));
+    results.push_back(InsertDynamicAlloc(op->getLoc(), resultType, op,
+      results_shape[index],
+      &rewriter));
+    return success();
+  };
+
+  if (op->getNumResults() == 1 && op->getResult(0).getType().isa<TupleType>()) {
+    SmallVector<Type, 4> fattenedTypes;
+    op->getResult(0).getType().dyn_cast<TupleType>().getFlattenedTypes(fattenedTypes);
+
+    for (auto result : llvm::enumerate(fattenedTypes)) {
+      if (failed(convert_result(result.value(), result.index()))) return failure();
+    }
+  } else {
+    for (auto result : llvm::enumerate(op->getResults())) {
+      if (failed(convert_result(result.value().getType(), result.index()))) return failure();
+    }
   }
+
   return success();
 }
 
@@ -183,6 +200,37 @@ class HloToLhloOpConverter<mhlo::DotOp> : public BaseOpConversion<mhlo::DotOp> {
   }
 };
 
+template <typename HloOpTy>
+class HloTupleOutputToLhloOpConverter : public BaseOpConversion<HloOpTy> {
+public:
+  using BaseOpConversion<HloOpTy>::BaseOpConversion;
+  LogicalResult matchAndRewrite(
+    HloOpTy hloOp, ArrayRef<Value> operands,
+    ConversionPatternRewriter& rewriter) const final {
+    Operation* op = hloOp.getOperation();
+    SmallVector<Operation*, 4> allUsers;
+    for (auto* user : op->getUsers()) {
+      allUsers.push_back(user);
+      if (!isa<mhlo::GetTupleElementOp>(user)) {
+        return failure();
+      }
+    }
+    SmallVector<Value, 4> buffer_args(operands.begin(), operands.end());
+    if (failed(ConvertResults(op, buffer_args, rewriter))) return failure();
+    rewriter.create<mhlo::HloToLhloOp<HloOpTy>>(op->getLoc(), llvm::None,
+      buffer_args, op->getAttrs());
+    for (auto* user : allUsers) {
+      auto getElementOp = cast<mhlo::GetTupleElementOp>(user);
+      unsigned index = op->getNumOperands() + getElementOp.index();
+      getElementOp.getResult().replaceAllUsesWith(buffer_args[index]);
+      rewriter.eraseOp(user);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct HloToLhloCustomCallOpConverter
     : public BaseOpConversion<mhlo::CustomCallOp> {
  public:
@@ -228,7 +276,7 @@ struct HloToLhloDotGeneralOpConverter
     std::array<Value, 3> bufferArgs = {operands[0], operands[1], {}};
 
     if (resultType.hasStaticShape()) {
-      bufferArgs[2] = InsertAlloc(op->getLoc(), result, &rewriter);
+      bufferArgs[2] = InsertAlloc(op->getLoc(), resultType, op, &rewriter);
     } else {
       SmallVector<Value, 1> results_shape;
       auto shape_type_op = dyn_cast<InferShapedTypeOpInterface>(op);
@@ -236,7 +284,7 @@ struct HloToLhloDotGeneralOpConverter
                                                      results_shape)))
         return failure();
 
-      bufferArgs[2] = InsertDynamicAlloc(op->getLoc(), result,
+      bufferArgs[2] = InsertDynamicAlloc(op->getLoc(), resultType, op,
                                          results_shape.front(), &rewriter);
     }
 
@@ -508,6 +556,8 @@ void populateHLOToLHLOConversionPattern(MLIRContext* context,
       HloToLhloOpConverter<mhlo::AddOp>,
       HloToLhloOpConverter<mhlo::AndOp>,
       HloToLhloOpConverter<mhlo::Atan2Op>,
+      HloTupleOutputToLhloOpConverter<mhlo::BatchNormGradOp>,
+      HloTupleOutputToLhloOpConverter<mhlo::BatchNormTrainingOp>,
       HloToLhloOpConverter<mhlo::BroadcastInDimOp>,
       HloToLhloOpConverter<mhlo::CeilOp>,
       HloToLhloOpConverter<mhlo::CompareOp>,

--- a/tests/hlo-legalize-to-lhlo.mlir
+++ b/tests/hlo-legalize-to-lhlo.mlir
@@ -606,4 +606,28 @@ func @zero_inputs() -> tensor<100x100xf32> {
   return %0 : tensor<100x100xf32>
 }
 
+// -----
+
+// CHECK-LABEL: func @batch_norm_training
+func @batch_norm_training(%arg0 : tensor<1x2x3xf32>) -> tensor<1x2x3xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<2xf32>
+  %1 = mhlo.constant dense<1.000000e+00> : tensor<2xf32>
+  // CHECK: "lmhlo.batch_norm_training"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
+  %2 = "mhlo.batch_norm_training"(%arg0, %1, %0) {epsilon = 9.99999974E-6 : f32, feature_index = 1 : i64} : (tensor<1x2x3xf32>, tensor<2xf32>, tensor<2xf32>) -> tuple<tensor<1x2x3xf32>, tensor<2xf32>, tensor<2xf32>>
+  %3 = "mhlo.get_tuple_element"(%2) {index = 0 : i32} : (tuple<tensor<1x2x3xf32>, tensor<2xf32>, tensor<2xf32>>) -> tensor<1x2x3xf32>
+  return %3 : tensor<1x2x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @batch_norm_grad
+func @batch_norm_grad(%arg0 : tensor<8x8x8x8xf32>, %arg1 : tensor<8x8x8x8xf32>) -> tensor<8x8x8x8xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<8xf32>
+  %1 = mhlo.constant dense<1.000000e+00> : tensor<8xf32>
+  // CHECK: "lmhlo.batch_norm_grad"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}},  %{{.*}}, %{{.*}})
+  %2 = "mhlo.batch_norm_grad"(%arg0, %1, %0, %1, %arg1) {epsilon = 9.99999974E-6 : f32, feature_index = 3 : i64} : (tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8x8x8x8xf32>) -> tuple<tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>>
+  %3 = "mhlo.get_tuple_element"(%2) {index = 0 : i32} : (tuple<tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>>) -> tensor<8x8x8x8xf32>
+  return %3 : tensor<8x8x8x8xf32>
+}
+
 

--- a/tests/hlo-legalize-to-lhlo.mlir
+++ b/tests/hlo-legalize-to-lhlo.mlir
@@ -624,7 +624,7 @@ func @batch_norm_training(%arg0 : tensor<1x2x3xf32>) -> tensor<1x2x3xf32> {
 func @batch_norm_grad(%arg0 : tensor<8x8x8x8xf32>, %arg1 : tensor<8x8x8x8xf32>) -> tensor<8x8x8x8xf32> {
   %0 = mhlo.constant dense<0.000000e+00> : tensor<8xf32>
   %1 = mhlo.constant dense<1.000000e+00> : tensor<8xf32>
-  // CHECK: "lmhlo.batch_norm_grad"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}},  %{{.*}}, %{{.*}})
+  // CHECK: "lmhlo.batch_norm_grad"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
   %2 = "mhlo.batch_norm_grad"(%arg0, %1, %0, %1, %arg1) {epsilon = 9.99999974E-6 : f32, feature_index = 3 : i64} : (tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8x8x8x8xf32>) -> tuple<tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>>
   %3 = "mhlo.get_tuple_element"(%2) {index = 0 : i32} : (tuple<tensor<8x8x8x8xf32>, tensor<8xf32>, tensor<8xf32>>) -> tensor<8x8x8x8xf32>
   return %3 : tensor<8x8x8x8xf32>


### PR DESCRIPTION
It basically resolved lowering of some op with a result as a tuple of tensors.
There seem only BatchNormTraining and BatchNormGrad requiring this.