### PR TITLE
Add an MHLO pass that lowers shape operations to scalar ops

### DIFF
--- a/include/mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.td
+++ b/include/mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.td
@@ -72,6 +72,11 @@ def HloLegalizeToLinalgPass : Pass<"hlo-legalize-to-linalg", "FuncOp"> {
   let constructor = "createLegalizeHloToLinalgPass()";
 }
 
+def HloLegalizeShapeComputationsPass : Pass<"hlo-legalize-shape-computations", "FuncOp"> {
+  let summary = "Legalize HLOs shape operations to core-mlir operations.";
+  let constructor = "createLegalizeHloShapeComputationsPass()";
+}
+
 def LegalizeToStandardPass : Pass<"mhlo-legalize-to-std", "FuncOp"> {
   let summary = "Legalize from MHLO dialect to standard dialect.";
   let constructor = "createLegalizeToStdPass()";

--- a/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
+++ b/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
@@ -62,6 +62,9 @@ createLegalizeHloShapeOpsToStandardPass();
 // Lowers from HLO dialect to Linalg dialect.
 std::unique_ptr<OperationPass<FuncOp>> createLegalizeHloToLinalgPass();
 
+// Lowers from HLO dialects dim operations.
+std::unique_ptr<OperationPass<FuncOp>> createLegalizeHloShapeComputationsPass();
+
 // Sinks constants implicitly captured in control flow regions. This is
 // necessary to export to XLA.
 std::unique_ptr<OperationPass<FuncOp>> createSinkConstantsToControlFlowPass();

--- a/include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h
+++ b/include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h
@@ -87,6 +87,10 @@ void populateHLOToLinalgConversionPattern(MLIRContext *context,
                                           TypeConverter &typeConverter,
                                           OwningRewritePatternList *patterns);
 
+// Collection of rewrite patterns for lowering of HLO dim operations.
+void populateHLOShapeComputationPatterns(MLIRContext *context,
+                                         OwningRewritePatternList *patterns);
+
 // Converter to signless intergers to be used with linalg conversion patterns.
 std::unique_ptr<TypeConverter> createHloToLinalgSignedIntegerConverter();
 

--- a/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -55,6 +55,7 @@ add_mlir_library(MhloPasses
   broadcast_propagation.cc
   expand_hlo_tuples.cc
   group_reduction_dimensions.cc
+  legalize_hlo_shape_computations.cc
   legalize_einsum_to_dot_general.cc
   legalize_gather_to_torch_index_select.cc
   legalize_trigonometric_to_approximation.cc

--- a/lib/Dialect/mhlo/transforms/legalize_hlo_shape_computations.cc
+++ b/lib/Dialect/mhlo/transforms/legalize_hlo_shape_computations.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Dialect/mhlo/transforms/legalize_hlo_shape_computations.cc
+++ b/lib/Dialect/mhlo/transforms/legalize_hlo_shape_computations.cc
@@ -1,0 +1,244 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements logic for lowering HLO/LHLO dialect to Linalg dialect.
+
+#include <algorithm>
+#include <numeric>
+#include <string>
+#include <utility>
+
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_attrs.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/PassDetail.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/map_mhlo_to_scalar_op.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/type_conversion.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringSet.h"
+
+namespace mlir {
+namespace {
+
+// We assume that if one of the operands is a FromElements operation that means
+// it is a shape computation.
+bool OpIsShapeComputation(Operation *op) {
+  bool found_from_elements = false;
+  for (auto operand : op->getOperands()) {
+    auto shaped_ty = operand.getType().template cast<ShapedType>();
+    if (!shaped_ty.hasRank() || shaped_ty.getRank() > 1)
+      return false;
+    if (auto from_elements =
+            operand.template getDefiningOp<tensor::FromElementsOp>()) {
+      found_from_elements = true;
+      continue;
+    }
+  }
+  return found_from_elements;
+}
+
+template <typename OpTy>
+class MhloMathOps : public OpRewritePattern<OpTy> {
+public:
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const final {
+    auto result_ty = op.getType().template cast<ShapedType>();
+    if (!result_ty.hasRank() || result_ty.getRank() > 1)
+      return failure();
+
+    if (!OpIsShapeComputation(op))
+      return failure();
+
+    Location loc = op.getLoc();
+    SmallVector<Value> operands;
+    for (int i = 0, s = result_ty.getNumElements(); i < s; i++) {
+      SmallVector<Value> extracts;
+      for (auto operand : op->getOperands()) {
+        ShapedType operand_ty = operand.getType().template cast<ShapedType>();
+        if (operand_ty.getRank() == 0) {
+          Value extract =
+              rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange({}));
+          extracts.push_back(extract);
+        } else {
+          Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
+          Value extract = rewriter.create<tensor::ExtractOp>(loc, operand, idx);
+          extracts.push_back(extract);
+        }
+      }
+
+      Value scalar_op = mhlo::MhloOpToStdScalarOp::map<OpTy>(
+          op, result_ty.getElementType(), extracts, &rewriter);
+      operands.push_back(scalar_op);
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, result_ty,
+                                                        operands);
+
+    return success();
+  }
+};
+
+class ConcatenateConverter : public OpRewritePattern<mhlo::ConcatenateOp> {
+public:
+  using OpRewritePattern<mhlo::ConcatenateOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::ConcatenateOp op,
+                                PatternRewriter &rewriter) const final {
+    auto result_ty = op.getType().cast<ShapedType>();
+    if (!result_ty.hasRank() || result_ty.getRank() > 1 ||
+        !result_ty.hasStaticShape())
+      return failure();
+
+    if (!OpIsShapeComputation(op))
+      return failure();
+
+    Location loc = op.getLoc();
+    llvm::SmallVector<Value> elements;
+    elements.reserve(result_ty.getNumElements());
+
+    for (auto operand : op->getOperands()) {
+      ShapedType operand_ty = operand.getType().template cast<ShapedType>();
+      if (operand_ty.getRank() == 0) {
+        Value extract =
+            rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange({}));
+        elements.push_back(extract);
+      } else {
+        for (int i = 0, s = operand_ty.getNumElements(); i < s; i++) {
+          Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
+          Value extract = rewriter.create<tensor::ExtractOp>(loc, operand, idx);
+          elements.push_back(extract);
+        }
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, result_ty,
+                                                        elements);
+    return success();
+  }
+};
+
+class GetDimSizeConverter : public OpRewritePattern<mhlo::GetDimensionSizeOp> {
+public:
+  using OpRewritePattern<mhlo::GetDimensionSizeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::GetDimensionSizeOp op,
+                                PatternRewriter &rewriter) const final {
+    Location loc = op.getLoc();
+    auto result_ty = op.getType();
+    auto element_ty = getElementTypeOrSelf(result_ty);
+    auto dim_attr = rewriter.getIndexAttr(op.dimension());
+    auto dim_const = rewriter.create<arith::ConstantOp>(loc, dim_attr);
+
+    Value dim_op = rewriter.create<tensor::DimOp>(loc, rewriter.getIndexType(),
+                                                  op.operand(), dim_const);
+
+    // Cast to the correct element type and convert to a tensor.
+    Value cast = rewriter.create<arith::IndexCastOp>(loc, element_ty, dim_op);
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, result_ty, cast);
+    return success();
+  }
+};
+
+class ReshapeConverter : public OpRewritePattern<mhlo::ReshapeOp> {
+public:
+  using OpRewritePattern<mhlo::ReshapeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::ReshapeOp op,
+                                PatternRewriter &rewriter) const final {
+    auto result_ty = op.getType().cast<ShapedType>();
+    if (!result_ty.hasRank() || result_ty.getRank() > 1 ||
+        !result_ty.hasStaticShape())
+      return failure();
+
+    auto from_elements = op.operand().getDefiningOp<tensor::FromElementsOp>();
+    if (!from_elements)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(
+        op, result_ty, from_elements.getOperands());
+    return success();
+  }
+};
+
+struct HloLegalizeShapeComputationsPass
+    : public mhlo::HloLegalizeShapeComputationsPassBase<
+          HloLegalizeShapeComputationsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithmeticDialect, math::MathDialect,
+                    StandardOpsDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext &ctx = getContext();
+    OwningRewritePatternList patterns(&ctx);
+
+    auto func = getOperation();
+    mhlo::populateHLOShapeComputationPatterns(&ctx, &patterns);
+    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+namespace mhlo {
+
+void populateHLOShapeComputationPatterns(MLIRContext *context,
+                                         OwningRewritePatternList *patterns) {
+  patterns->insert<MhloMathOps<mhlo::AbsOp>, MhloMathOps<mhlo::AddOp>,
+                   MhloMathOps<mhlo::AndOp>, MhloMathOps<mhlo::CeilOp>,
+                   MhloMathOps<mhlo::ConvertOp>, MhloMathOps<mhlo::DivOp>,
+                   MhloMathOps<mhlo::FloorOp>, MhloMathOps<mhlo::MaxOp>,
+                   MhloMathOps<mhlo::MinOp>, MhloMathOps<mhlo::MulOp>,
+                   MhloMathOps<mhlo::NegOp>, MhloMathOps<mhlo::RoundOp>,
+                   MhloMathOps<mhlo::RsqrtOp>, MhloMathOps<mhlo::SqrtOp>,
+                   MhloMathOps<mhlo::SubOp>, ConcatenateConverter,
+                   GetDimSizeConverter, ReshapeConverter>(context);
+}
+
+std::unique_ptr<OperationPass<FuncOp>>
+createLegalizeHloShapeComputationsPass() {
+  return std::make_unique<HloLegalizeShapeComputationsPass>();
+}
+
+} // namespace mhlo
+} // namespace mlir

--- a/tests/Dialect/mhlo/legalize-hlo-shape-computations.mlir
+++ b/tests/Dialect/mhlo/legalize-hlo-shape-computations.mlir
@@ -1,0 +1,71 @@
+// RUN: mlir-hlo-opt %s -hlo-legalize-shape-computations -split-input-file | FileCheck %s
+
+ // CHECK-LABEL: func @get_dimension_size
+func @get_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<i32>) { 
+  %1 = "mhlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32> 
+  return %1 : tensor<i32>
+} 
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK: return %[[FROM]] : tensor<i32>
+
+// -----
+
+ // CHECK-LABEL: func @reshape_dimension_size
+func @reshape_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<1xi32>) { 
+  %0 = "mhlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32> 
+  %1 = "mhlo.reshape"(%0) : (tensor<i32>) -> tensor<1xi32>
+  return %1 : tensor<1xi32>
+} 
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK: return %[[FROM]] : tensor<1xi32>
+
+// -----
+
+// CHECK-LABEL: func @multiply_dimension_size
+func @multiply_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<i32>) { 
+  %0 = mhlo.constant dense<2> : tensor<i32>
+  %1 = "mhlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32> 
+  %2 = "mhlo.multiply"(%0, %1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+  return %2 : tensor<i32>
+} 
+
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK-DAG: %[[EXTRACT:.+]] = tensor.extract %[[FROM]][]
+// CHECK-DAG: %[[MUL:.+]] = arith.muli %[[EXTRACT]], %[[C2]]
+// CHECK-DAG: %[[RES:.+]] = tensor.from_elements %[[MUL]]
+// CHECK: return %[[RES]]
+
+// -----
+
+// CHECK-LABEL: func @concat_dimension_size
+func @concat_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<2xi32>) { 
+  %0 = "mhlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32> 
+  %1 = "mhlo.reshape"(%0) : (tensor<i32>) -> tensor<1xi32>
+  %2 = mhlo.constant dense<2> : tensor<1xi32>
+  %3 = "mhlo.concatenate"(%1, %2) {dimension = 0 : i64} : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  return %3 : tensor<2xi32>
+} 
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK-DAG: %[[EXTRACT:.+]] = tensor.extract %[[FROM]][%[[C0]]]
+// CHECK-DAG: %[[RES:.+]] = tensor.from_elements %[[EXTRACT]], %[[C2]]
+// CHECK: return %[[RES]]
+


### PR DESCRIPTION
MHLO operations that compute shapes need to be computed at stack level instead
of occurring as tensor operations. This pass attempts to infer these cases by
checking for FromElements operations.