### PR TITLE
Fixed dot_general to regular dot.

### DIFF
--- a/lib/Dialect/mhlo/transforms/lower_general_dot.cc
+++ b/lib/Dialect/mhlo/transforms/lower_general_dot.cc
@@ -199,19 +199,13 @@ struct GeneralDotConvert : public OpRewritePattern<DotGeneralOp> {
     RankedTensorType rhs_ty = rhs.getType().dyn_cast<RankedTensorType>();
     if (!lhs_ty || !rhs_ty) return failure();
 
-    if (!(lhs_contracting_dims.size() == 1 &&
-          lhs_contracting_dims.front() == 1)) {
-      lhs = ProcessDotArg(op.lhs(), op.getLoc(),
-                          dot_numbers.getLhsContractingDimensions(),
-                          /*outer_dims_first=*/true, rewriter);
-    }
+    lhs = ProcessDotArg(op.lhs(), op.getLoc(),
+                        dot_numbers.getLhsContractingDimensions(),
+                        /*outer_dims_first=*/true, rewriter);
 
-    if (!(rhs_contracting_dims.size() == 1 &&
-          rhs_contracting_dims.front() == 0)) {
-      rhs = ProcessDotArg(op.rhs(), op.getLoc(),
-                          dot_numbers.getRhsContractingDimensions(),
-                          /*outer_dims_first=*/false, rewriter);
-    }
+    rhs = ProcessDotArg(op.rhs(), op.getLoc(),
+                        dot_numbers.getRhsContractingDimensions(),
+                        /*outer_dims_first=*/false, rewriter);
 
     // Accept only static shaped types.
     auto lhs_shape_type = lhs.getType().dyn_cast_or_null<ShapedType>();

--- a/tests/Dialect/mhlo/lower-general-dot.mlir
+++ b/tests/Dialect/mhlo/lower-general-dot.mlir
@@ -88,3 +88,20 @@ func @dot_general_to_dot_dynamic(%arg0: tensor<128x4x?x32xf32>, %arg1: tensor<8x
 // CHECK-DAG: %[[DR3:.+]] = "mhlo.dynamic_reshape"(%[[DOT]], %[[CONCAT3]])
 // CHECK: return %[[DR3]]
 
+
+// -----
+
+func @dot_no_rhs_batch(%arg0: tensor<1x512x768xf32>, %arg1: tensor<768x12x64xf32>) -> tensor<1x512x12x64xf32> {
+  %0 = "mhlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #mhlo.dot<
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [0]>
+    } : (tensor<1x512x768xf32>, tensor<768x12x64xf32>) -> tensor<1x512x12x64xf32>
+  return %0 : tensor<1x512x12x64xf32>
+}
+
+// CHECK-LABEL:  func @dot_no_rhs_batch
+// CHECK:          %[[RESHAPEL:.+]] = "mhlo.reshape"(%arg0) : (tensor<1x512x768xf32>) -> tensor<512x768xf32>
+// CHECK:          %[[RESHAPER:.+]] = "mhlo.reshape"(%arg1) : (tensor<768x12x64xf32>) -> tensor<768x768xf32>
+// CHECK:          %[[DOT:.+]] = "mhlo.dot"(%[[RESHAPEL]], %[[RESHAPER]]) : (tensor<512x768xf32>, tensor<768x768xf32>) -> tensor<512x768xf32>
+// CHECK:          %[[OUT:.+]] = "mhlo.reshape"(%[[DOT]]) : (tensor<512x768xf32>) -> tensor<1x512x12x64xf32>


### PR DESCRIPTION
Lower general dot attempted to avoid extra reshapes but made assumption that
all types of dimensions would be contained. Fixed to not make this assumption.