### PR TITLE
Generalize einsum to dot_general lowering to allow transposed results.

### DIFF
--- a/lib/Dialect/mhlo/transforms/legalize_einsum_to_dot_general.cc
+++ b/lib/Dialect/mhlo/transforms/legalize_einsum_to_dot_general.cc
@@ -41,7 +41,7 @@ struct EinsumToDotGeneralPattern : public OpRewritePattern<EinsumOp> {
                                 PatternRewriter &rewriter) const override {
     StringRef equation = einsum.einsum_config();
     SmallVector<char> lhs_tokens, rhs_tokens;
-    llvm::SmallDenseSet<char> result_tokens;
+    SmallVector<char> result_tokens;
     size_t index = 0;
     enum EquationVariable { kIsLhs, kIsRhs, kIsResult };
     EquationVariable current_variable = kIsLhs;
@@ -52,7 +52,7 @@ struct EinsumToDotGeneralPattern : public OpRewritePattern<EinsumOp> {
         } else if (current_variable == kIsRhs) {
           rhs_tokens.push_back(equation[index]);
         } else {
-          result_tokens.insert(equation[index]);
+          result_tokens.push_back(equation[index]);
         }
       } else if (equation.substr(index, 1).contains(",")) {
         current_variable = kIsRhs;
@@ -66,39 +66,109 @@ struct EinsumToDotGeneralPattern : public OpRewritePattern<EinsumOp> {
       }
       index++;
     }
-    assert(lhs_tokens.size() ==
-           einsum.lhs().getType().cast<RankedTensorType>().getRank());
-    assert(rhs_tokens.size() ==
-           einsum.rhs().getType().cast<RankedTensorType>().getRank());
 
-    auto collect_contracting_batching_dims =
-        [&](SmallVector<char> tokens, SmallVector<char> others,
-            SmallVectorImpl<int64_t> &contracting_dims,
-            SmallVectorImpl<int64_t> &batching_dims) {
-          llvm::SmallDenseSet<char> others_set(others.begin(), others.end());
-          for (const auto &en : llvm::enumerate(tokens)) {
-            if (!result_tokens.contains(en.value())) {
-              contracting_dims.emplace_back(en.index());
-            }
-            if (others_set.contains(en.value()) &&
-                result_tokens.contains(en.value())) {
-              batching_dims.emplace_back(en.index());
-            }
-          }
-        };
+    auto lhs_type = einsum.lhs().getType().cast<RankedTensorType>();
+    auto rhs_type = einsum.rhs().getType().cast<RankedTensorType>();
+    assert(static_cast<int64_t>(lhs_tokens.size()) == lhs_type.getRank());
+    assert(static_cast<int64_t>(rhs_tokens.size()) == rhs_type.getRank());
+
+    auto collect_operand_dims = [&](RankedTensorType operand_type,
+                                    SmallVector<char> operand_tokens,
+                                    SmallVector<char> others,
+                                    SmallVectorImpl<int64_t> &contracting_dims,
+                                    SmallVectorImpl<int64_t> &batching_dims,
+                                    SmallVector<char> &dot_result_tokens,
+                                    SmallVector<int64_t> &dot_result_shape) {
+      llvm::SmallDenseSet<char> others_set(others.begin(), others.end());
+      llvm::SmallDenseSet<char> result_tokens_set(result_tokens.begin(),
+                                                  result_tokens.end());
+      for (const auto &en : llvm::enumerate(operand_tokens)) {
+        bool isResultToken = result_tokens_set.contains(en.value());
+        bool isOtherToken = others_set.contains(en.value());
+
+        if (!isResultToken) {
+          contracting_dims.push_back(en.index());
+        } else if (isOtherToken) {
+          batching_dims.push_back(en.index());
+        } else {
+          dot_result_tokens.push_back(en.value());
+          dot_result_shape.push_back(operand_type.getShape()[en.index()]);
+        }
+      }
+    };
+    // Indices of batch and contracting dims, relative to each operand's
+    // dimensions.
     SmallVector<int64_t> lhs_contracting_dims, lhs_batching_dims,
         rhs_contracting_dims, rhs_batching_dims;
-    collect_contracting_batching_dims(lhs_tokens, rhs_tokens,
-                                      lhs_contracting_dims, lhs_batching_dims);
-    collect_contracting_batching_dims(rhs_tokens, lhs_tokens,
-                                      rhs_contracting_dims, rhs_batching_dims);
+    // Tokens representing the natural order of the dot_general op (i.e.
+    // the lhs non-contracting followed by rhs non-contracting tokens).
+    SmallVector<char> dot_result_tokens;
+    SmallVector<int64_t> dot_result_shape;
 
+    collect_operand_dims(lhs_type, lhs_tokens, rhs_tokens, lhs_contracting_dims,
+                         lhs_batching_dims, dot_result_tokens,
+                         dot_result_shape);
+    collect_operand_dims(rhs_type, rhs_tokens, lhs_tokens, rhs_contracting_dims,
+                         rhs_batching_dims, dot_result_tokens,
+                         dot_result_shape);
+
+    // Prepend batch tokens.
+    for (const auto &it : llvm::enumerate(lhs_batching_dims)) {
+      char batching_token = lhs_tokens[it.value()];
+      int64_t batching_shape_dim = lhs_type.getShape()[it.value()];
+      dot_result_tokens.insert(dot_result_tokens.begin() + it.index(),
+                               batching_token);
+      dot_result_shape.insert(dot_result_shape.begin() + it.index(),
+                              batching_shape_dim);
+    }
+
+    // Lowering to dot_general does not support a mismatch between the number
+    // of result dims and the number of non-contracting dims.
+    if (dot_result_tokens.size() != result_tokens.size()) {
+      return rewriter.notifyMatchFailure(einsum,
+                                         "rank reducing einsum not supported");
+    }
+
+    // Generate a permutation sequence based on result tokens.
+    SmallVector<int64_t> result_perms;
+    bool is_natural_order = true;
+    for (char result_token : result_tokens) {
+      auto found_it = std::find(dot_result_tokens.begin(),
+                                dot_result_tokens.end(), result_token);
+      if (found_it == dot_result_tokens.end()) {
+        return rewriter.notifyMatchFailure(
+            einsum, "result token not found in operands");
+      }
+      auto result_index = std::distance(dot_result_tokens.begin(), found_it);
+      if (result_perms.empty()) {
+        if (result_index != 0) {
+          is_natural_order = false;
+        }
+      } else if (result_index != (result_perms.back() + 1)) {
+        is_natural_order = false;
+      }
+      result_perms.push_back(result_index);
+    }
+
+    // Emit the dot_general, using its native result ordering.
+    auto dot_general_result_type = RankedTensorType::get(
+        ArrayRef<int64_t>(dot_result_shape), lhs_type.getElementType());
     auto dim_numbers = mhlo::DotDimensionNumbersAttr::get(
         rewriter.getContext(), lhs_batching_dims, rhs_batching_dims,
         lhs_contracting_dims, rhs_contracting_dims);
-    rewriter.replaceOpWithNewOp<DotGeneralOp>(
-        einsum, einsum.getType(), einsum.lhs(), einsum.rhs(), dim_numbers,
-        /*precision_config=*/ArrayAttr{});
+    auto dot_general_op =
+        rewriter.create<DotGeneralOp>(einsum.getLoc(), dot_general_result_type,
+                                      einsum.lhs(), einsum.rhs(), dim_numbers,
+                                      /*precision_config=*/ArrayAttr{});
+
+    if (is_natural_order) {
+      // The dot_general is already in an appropriate result order.
+      rewriter.replaceOp(einsum, ValueRange{dot_general_op});
+    } else {
+      // Generate a transpose.
+      rewriter.replaceOpWithNewOp<TransposeOp>(
+          einsum, dot_general_op, rewriter.getI64TensorAttr(result_perms));
+    }
     return success();
   }
 };
@@ -115,7 +185,7 @@ struct LegalizeEinsumToDotGeneralPass
     }
   }
 };
-}  // namespace
+} // namespace
 
 void PopulateEinsumToDotGeneralPatterns(mlir::MLIRContext *context,
                                         RewritePatternSet *patterns) {
@@ -126,5 +196,5 @@ std::unique_ptr<OperationPass<FuncOp>> createLegalizeEinsumToDotGeneralPass() {
   return std::make_unique<LegalizeEinsumToDotGeneralPass>();
 }
 
-}  // namespace mhlo
-}  // namespace mlir
+} // namespace mhlo
+} // namespace mlir

--- a/lib/Dialect/mhlo/transforms/lower_general_dot.cc
+++ b/lib/Dialect/mhlo/transforms/lower_general_dot.cc
@@ -198,19 +198,13 @@ struct GeneralDotConvert : public OpRewritePattern<DotGeneralOp> {
     RankedTensorType rhs_ty = rhs.getType().dyn_cast<RankedTensorType>();
     if (!lhs_ty || !rhs_ty) return failure();
 
-    if (!(lhs_contracting_dims.size() == 1 &&
-          lhs_contracting_dims.front() == 1)) {
-      lhs = ProcessDotArg(op.lhs(), op.getLoc(),
-                          dot_numbers.getLhsContractingDimensions(),
-                          /*outer_dims_first=*/true, rewriter);
-    }
+    lhs = ProcessDotArg(op.lhs(), op.getLoc(),
+                        dot_numbers.getLhsContractingDimensions(),
+                        /*outer_dims_first=*/true, rewriter);
 
-    if (!(rhs_contracting_dims.size() == 1 &&
-          rhs_contracting_dims.front() == 0)) {
-      rhs = ProcessDotArg(op.rhs(), op.getLoc(),
-                          dot_numbers.getRhsContractingDimensions(),
-                          /*outer_dims_first=*/false, rewriter);
-    }
+    rhs = ProcessDotArg(op.rhs(), op.getLoc(),
+                        dot_numbers.getRhsContractingDimensions(),
+                        /*outer_dims_first=*/false, rewriter);
 
     // Accept only static shaped types.
     auto lhs_shape_type = lhs.getType().dyn_cast_or_null<ShapedType>();

--- a/tests/Dialect/mhlo/hlo-legalize-einsum-to-dot-general.mlir
+++ b/tests/Dialect/mhlo/hlo-legalize-einsum-to-dot-general.mlir
@@ -6,11 +6,12 @@ func @einsum_diag(%arg0: tensor<6x6xf32>) -> tensor<6xf32> {
   return %1 : tensor<6xf32>
 }
 // CHECK-LABEL: func @einsum_diag
+// NOTE: 2-operand diagonal not supported as a dot_general lowering.
+// NOTE: It can be lowered into another form. Perhaps support that in the
+// NOTE: future.
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
 // CHECK:         %[[CST:.+]] = mhlo.constant dense<{{.*}} : tensor<f32>
-// CHECK:         %{{.+}} = "mhlo.dot_general"(%[[CST]], %[[ARG0]])
-// CHECK-SAME:          dot_dimension_numbers = #mhlo.dot<>
-// CHECK-SAME:    : (tensor<f32>, tensor<6x6xf32>) -> tensor<6xf32>
+// CHECK:         "mhlo.einsum"
 
 func @einsum_batched_matrix_high_rank_vector_mul(%arg0: tensor<8x2x6xf32>, %arg1: tensor<8x5x3x6xf32>) -> tensor<8x5x3x2xf32> {
   %0 = "mhlo.einsum"(%arg0, %arg1) {einsum_config = "bxy,bijy->bijx"} : (tensor<8x2x6xf32>, tensor<8x5x3x6xf32>) -> tensor<8x5x3x2xf32>
@@ -19,13 +20,16 @@ func @einsum_batched_matrix_high_rank_vector_mul(%arg0: tensor<8x2x6xf32>, %arg1
 // CHECK-LABEL: func @einsum_batched_matrix_high_rank_vector_mul
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
-// CHECK:         %{{.+}} = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]])
+// CHECK:         %[[DG:.+]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]])
 // CHECK-SAME:      dot_dimension_numbers =
 // CHECK-SAME:        lhs_batching_dimensions = [0]
 // CHECK-SAME:        rhs_batching_dimensions = [0]
 // CHECK-SAME:        lhs_contracting_dimensions = [2]
 // CHECK-SAME:        rhs_contracting_dimensions = [3]
-// CHECK-SAME:    : (tensor<8x2x6xf32>, tensor<8x5x3x6xf32>) -> tensor<8x5x3x2xf32>
+// CHECK-SAME:    : (tensor<8x2x6xf32>, tensor<8x5x3x6xf32>) -> tensor<8x2x5x3xf32>
+// CHECK:         %[[T:.+]] = "mhlo.transpose"(%[[DG]])
+// CHECK-SAME:      permutation = dense<[0, 2, 3, 1]
+// CHECK-SAME:    : (tensor<8x2x5x3xf32>) -> tensor<8x5x3x2xf32>
 
 func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = "mhlo.einsum"(%arg0, %arg1) {einsum_config = "ij,jk->ik"} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>


### PR DESCRIPTION
This allows ops like this to be lowered properly (was generated illegal dot_general ops):
```
    "mhlo.einsum"(%424, %298) {einsum_config = "abd,abc->cd"} : (tensor<1x512x768xf32>, tensor<1x512x3072xf32>) -> tensor<3072x768xf32>
```

I found the existing lowering quite buggy, and I believe that two of the tests are incorrect, generating dot_general ops that are actually illegal. MHLO is so under-specified, though, that it is next to impossible to say, so I am just applying best judgment.