### PR TITLE
Update lowering from mhlo.dynamic_slice to linalg for index computations

### DIFF
--- a/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
+++ b/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
@@ -1048,8 +1048,7 @@ class RealDynamicSliceConverter
     auto resultType =
         this->typeConverter->convertType(realDynamicSliceOp.getType())
             .cast<RankedTensorType>();
-    Value zero =
-        rewriter.create<arith::ConstantOp>(loc, IntegerAttr::get(arithType, 0));
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     SmallVector<OpFoldResult, 4> offsets, sizes, strides;
     SmallVector<Type, 3> clampType(3, arithType);
     for (auto i : llvm::seq<unsigned>(0, argType.getRank())) {
@@ -1070,6 +1069,10 @@ class RealDynamicSliceConverter
               ? computeSize(loc, start, limit, stride, rewriter)
               : rewriter.create<arith::ConstantIndexOp>(loc, resultDimSize);
 
+      // We can now convert start to index.
+      start = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(),
+                                                  start);
+
       // Fetch i-th dimension size of the operand and calculate upper bound as
       //   ub = operand_dim[i] - size[i]
       Value operandDimSize =
@@ -1080,15 +1083,10 @@ class RealDynamicSliceConverter
       // We clamp the start_index to keep it bounded as
       //   0 <= start_index[i] <= ub
       // Clamp does not support index type, so cast to integer type.
-      start = rewriter.createOrFold<arith::IndexCastOp>(loc, arithType, start);
-      upperBound =
-          rewriter.createOrFold<arith::IndexCastOp>(loc, arithType, upperBound);
-      start = mhlo::MhloOpToStdScalarOp::mapOpOfType<mhlo::ClampOp>(
-          loc, arithType, clampType, ValueRange{zero, start, upperBound},
-          &rewriter);
+      start = rewriter.create<arith::MaxSIOp>(loc, start, zero);
+      start = rewriter.create<arith::MinSIOp>(loc, start, upperBound);
 
-      offsets.push_back(
-          rewriter.createOrFold<arith::IndexCastOp>(loc, indexType, start));
+      offsets.push_back(start);
       if (ShapedType::isDynamic(resultDimSize))
         sizes.push_back(size);
       else
@@ -1449,11 +1447,6 @@ class DynamicSliceConverter : public OpConversionPattern<mhlo::DynamicSliceOp> {
 
     auto indexType = rewriter.getIndexType();
     SmallVector<OpFoldResult, 3> startIndices, sizes;
-    Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(adaptor.start_indices()[0]
-                                      .getType()
-                                      .cast<RankedTensorType>()
-                                      .getElementType()));
     for (auto& en : llvm::enumerate(
              llvm::zip(adaptor.start_indices(),
                        dynamicSliceOp.slice_sizes().getValues<int64_t>()))) {
@@ -1465,24 +1458,20 @@ class DynamicSliceConverter : public OpConversionPattern<mhlo::DynamicSliceOp> {
       //       0, operand.dimension_size[i] - size_indices[i])`
       Value startIndex =
           rewriter.create<tensor::ExtractOp>(loc, std::get<0>(en.value()));
-      Value ub = rewriter.createOrFold<tensor::DimOp>(loc, adaptor.operand(),
+      startIndex = rewriter.createOrFold<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(), startIndex);
+
+      Value mn = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+      Value mx = rewriter.createOrFold<tensor::DimOp>(loc, adaptor.operand(),
                                                       en.index());
-      // ClampOp lowering does not support index type, so cast it into integer
-      // type.
-      ub = rewriter.createOrFold<arith::IndexCastOp>(loc, startIndex.getType(),
-                                                     ub);
-      ub = rewriter.createOrFold<arith::SubIOp>(
-          loc, ub,
-          rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getIntegerAttr(startIndex.getType(), size)));
-      startIndex = mhlo::MhloOpToStdScalarOp::mapOpOfType<mhlo::ClampOp>(
-          loc, startIndex.getType(),
-          ArrayRef<Type>{startIndex.getType(), startIndex.getType(),
-                         startIndex.getType()},
-          ArrayRef<Value>{zero, startIndex, ub}, &rewriter);
-      startIndices.push_back(
-          rewriter.create<arith::IndexCastOp>(loc, indexType, startIndex)
-              .getResult());
+      mx = rewriter.createOrFold<arith::SubIOp>(
+          loc, mx, rewriter.create<arith::ConstantIndexOp>(loc, size));
+
+      startIndex = rewriter.create<arith::MaxSIOp>(loc, startIndex, mn);
+      startIndex = rewriter.create<arith::MinSIOp>(loc, startIndex, mx);
+
+      startIndices.push_back(startIndex);
     }
 
     int64_t rank = argType.getRank();

--- a/tests/Dialect/mhlo/hlo-legalize-to-linalg.mlir
+++ b/tests/Dialect/mhlo/hlo-legalize-to-linalg.mlir
@@ -788,7 +788,7 @@ func.func @real_dynamic_slice(%input: tensor<256x?xf32>, %start_indices: tensor<
   %0 = "mhlo.real_dynamic_slice"(%input, %start_indices, %limit_indices, %strides) : (tensor<256x?xf32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<256x?xf32>
   func.return %0 : tensor<256x?xf32>
 }
-// CHECK-NEXT: %[[ZERO:.*]] = arith.constant 0 : i64
+// CHECK-NEXT: %[[ZERO:.*]] = arith.constant 0 : index
 
 // 1.   For dimension 0.
 // CHECK-NEXT: %[[DIM0:.*]] = arith.constant 0 : index
@@ -808,11 +808,8 @@ func.func @real_dynamic_slice(%input: tensor<256x?xf32>, %start_indices: tensor<
 
 // 1.4. Clamp starting index : 0 <= start <= ub
 //      where upper bound (ub) is computed at step 1.3
-// CHECK-NEXT: %[[START0_Int:.*]] = arith.index_cast %[[START0]] : index to i64
-// CHECK-NEXT: %[[UB0:.*]] = arith.constant 0 : i64
-// CHECK-NEXT: %[[MAX0:.*]] = arith.maxsi %[[ZERO]], %[[START0_Int]] : i64
-// CHECK-NEXT: %[[MIN0:.*]] = arith.minsi %[[MAX0]], %[[UB0]] : i64
-// CHECK-NEXT: %[[CLAMPED_START0:.*]] = arith.index_cast %[[MIN0]] : i64 to index
+// CHECK-NEXT: %[[MAX0:.*]] = arith.maxsi %[[START0]], %[[ZERO]] : index
+// CHECK-NEXT: %[[MIN0:.*]] = arith.minsi %[[MAX0]], %[[UB]] : index
 
 // 2.   For dimension 1.
 // CHECK-NEXT: %[[DIM1:.*]] = arith.constant 1 : index
@@ -834,13 +831,10 @@ func.func @real_dynamic_slice(%input: tensor<256x?xf32>, %start_indices: tensor<
 
 // 2.4. Clamp starting index : 0 <= start <= ub
 //      where upper bound (ub) is computed at step 2.3
-// CHECK-NEXT: %[[START1_Int:.*]] = arith.index_cast %[[START1]] : index to i64
-// CHECK-NEXT: %[[UB1:.*]] = arith.index_cast %[[UB]] : index to i64
-// CHECK-NEXT: %[[MAX1:.*]] = arith.maxsi %[[ZERO]], %[[START1_Int]] : i64
-// CHECK-NEXT: %[[MIN1:.*]] = arith.minsi %[[MAX1]], %[[UB1]] : i64
-// CHECK-NEXT: %[[CLAMPED_START1:.*]] = arith.index_cast %[[MIN1]] : i64 to index
+// CHECK-NEXT: %[[MAX1:.*]] = arith.maxsi %[[START1]], %[[ZERO]] : index
+// CHECK-NEXT: %[[MIN1:.*]] = arith.minsi %[[MAX1]], %[[UB]] : index
 
-// CHECK-NEXT: %[[SLICE:.*]] = tensor.extract_slice %[[OPERAND]][%[[CLAMPED_START0]], %[[CLAMPED_START1]]] [256, %[[SIZE1]]] [%[[STRIDE0]], %[[STRIDE1]]] : tensor<256x?xf32> to tensor<256x?xf32>
+// CHECK-NEXT: %[[SLICE:.*]] = tensor.extract_slice %[[OPERAND]][%[[MIN0]], %[[MIN1]]] [256, %[[SIZE1]]] [%[[STRIDE0]], %[[STRIDE1]]] : tensor<256x?xf32> to tensor<256x?xf32>
 // CHECK-NEXT: return %[[SLICE]] : tensor<256x?xf32>
 
 // -----
@@ -2947,18 +2941,19 @@ func.func @dynamic_slice(%arg: tensor<3x4xf32>, %start1: tensor<i64>, %start2: t
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
-// CHECK:         %[[C0:.*]] = arith.constant 0 : i64
-// CHECK:         %[[SCALAR1:.*]] = tensor.extract %[[ARG1]][] : tensor<i64>
-// CHECK:         %[[UB1:.*]] = arith.constant 2 : i64
-// CHECK:         %[[T1:.*]] = arith.maxsi %[[C0]], %[[SCALAR1]] : i64
-// CHECK:         %[[CLAMPED1:.*]] = arith.minsi %[[T1]], %[[UB1]] : i64
-// CHECK:         %[[START1:.*]] = arith.index_cast %[[CLAMPED1]] : i64 to index
-// CHECK:         %[[SCALAR2:.*]] = tensor.extract %[[ARG2]][] : tensor<i64>
-// CHECK:         %[[UB2:.*]] = arith.constant 0 : i64
-// CHECK:         %[[T2:.*]] = arith.maxsi %[[C0]], %[[SCALAR2]] : i64
-// CHECK:         %[[CLAMPED2:.*]] = arith.minsi %[[T2]], %[[UB2]] : i64
-// CHECK:         %[[START2:.*]] = arith.index_cast %[[CLAMPED2]] : i64 to index
-// CHECK:           tensor.extract_slice %[[ARG0]][%[[START1]], %[[START2]]] [1, 4] [1, 1]
+// CHECK:         %[[EXTRACT1:.*]] = tensor.extract %[[ARG1]][] : tensor<i64>
+// CHECK:         %[[SCALAR1:.*]] = arith.index_cast %[[EXTRACT1]]
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[UB1:.*]] = arith.constant 2 : index
+// CHECK:         %[[T1:.*]] = arith.maxsi %[[SCALAR1]], %[[C0]] : index
+// CHECK:         %[[CLAMPED1:.*]] = arith.minsi %[[T1]], %[[UB1]] : index
+// CHECK:         %[[EXTRACT2:.*]] = tensor.extract %[[ARG2]][] : tensor<i64>
+// CHECK:         %[[SCALAR2:.*]] = arith.index_cast %[[EXTRACT2]]
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[UB2:.*]] = arith.constant 0 : index
+// CHECK:         %[[T2:.*]] = arith.maxsi %[[SCALAR2]], %[[C0]] : index
+// CHECK:         %[[CLAMPED2:.*]] = arith.minsi %[[T2]], %[[UB2]] : index
+// CHECK:           tensor.extract_slice %[[ARG0]][%[[CLAMPED1]], %[[CLAMPED2]]] [1, 4] [1, 1]
 
 // -----
 
@@ -2974,18 +2969,19 @@ func.func @dynamic_slice_unsigned(%arg: tensor<3x4xui32>, %start1: tensor<i64>, 
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
 // CHECK:         %[[SIGNLESS_ARG0:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : tensor<3x4xui32> to tensor<3x4xi32>
-// CHECK:         %[[C0:.*]] = arith.constant 0 : i64
-// CHECK:         %[[SCALAR1:.*]] = tensor.extract %[[ARG1]][] : tensor<i64>
-// CHECK:         %[[UB1:.*]] = arith.constant 2 : i64
-// CHECK:         %[[T1:.*]] = arith.maxsi %[[C0]], %[[SCALAR1]] : i64
-// CHECK:         %[[CLAMPED1:.*]] = arith.minsi %[[T1]], %[[UB1]] : i64
-// CHECK:         %[[START1:.*]] = arith.index_cast %[[CLAMPED1]] : i64 to index
-// CHECK:         %[[SCALAR2:.*]] = tensor.extract %[[ARG2]][] : tensor<i64>
-// CHECK:         %[[UB2:.*]] = arith.constant 0 : i64
-// CHECK:         %[[T2:.*]] = arith.maxsi %[[C0]], %[[SCALAR2]] : i64
-// CHECK:         %[[CLAMPED2:.*]] = arith.minsi %[[T2]], %[[UB2]] : i64
-// CHECK:         %[[START2:.*]] = arith.index_cast %[[CLAMPED2]] : i64 to index
-// CHECK:           tensor.extract_slice %[[SIGNLESS_ARG0]][%[[START1]], %[[START2]]] [1, 4] [1, 1]
+// CHECK:         %[[EXTRACT1:.*]] = tensor.extract %[[ARG1]][] : tensor<i64>
+// CHECK:         %[[SCALAR1:.*]] = arith.index_cast %[[EXTRACT1]]
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[UB1:.*]] = arith.constant 2 : index
+// CHECK:         %[[T1:.*]] = arith.maxsi %[[SCALAR1]], %[[C0]] : index
+// CHECK:         %[[CLAMPED1:.*]] = arith.minsi %[[T1]], %[[UB1]] : index
+// CHECK:         %[[EXTRACT2:.*]] = tensor.extract %[[ARG2]][] : tensor<i64>
+// CHECK:         %[[SCALAR2:.*]] = arith.index_cast %[[EXTRACT2]]
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[UB2:.*]] = arith.constant 0 : index
+// CHECK:         %[[T2:.*]] = arith.maxsi %[[SCALAR2]], %[[C0]] : index
+// CHECK:         %[[CLAMPED2:.*]] = arith.minsi %[[T2]], %[[UB2]] : index
+// CHECK:           tensor.extract_slice %[[SIGNLESS_ARG0]][%[[CLAMPED1]], %[[CLAMPED2]]] [1, 4] [1, 1]
 
 // -----
 


### PR DESCRIPTION
Index computations were done by whatever the offset / size type is.
These computations need to be performed with IndexType to guarantee that
the values lay in the bounds of the shape dimension size.