### PR TITLE
Add canonicalization for mhlo.dynamic_conv to mhlo.convolution

### DIFF
--- a/mhlo/IR/hlo_ops.cc
+++ b/mhlo/IR/hlo_ops.cc
@@ -2554,6 +2554,48 @@ LogicalResult ConvolutionOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// DynamicConvOp
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct DynamicConvIsConv : public OpRewritePattern<mhlo::DynamicConvOp> {
+  using OpRewritePattern<mhlo::DynamicConvOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(mhlo::DynamicConvOp op,
+                                PatternRewriter &rewriter) const override {
+    DenseIntElementsAttr padAttr;
+    if (!matchPattern(op.getDPadding(), m_Constant(&padAttr))) {
+      return rewriter.notifyMatchFailure(op, "non-constant d_padding found");
+    }
+
+    SmallVector<int64_t> padArray;
+    for (APInt pad : padAttr.getValues<APInt>()) {
+      padArray.push_back(pad.getZExtValue());
+    }
+
+    int64_t paddedDimCount = padArray.size() / 2;
+    auto newPadAttr = DenseIntElementsAttr::get(
+        RankedTensorType::get({paddedDimCount, 2}, rewriter.getI64Type()),
+        padArray);
+
+    rewriter.replaceOpWithNewOp<mhlo::ConvolutionOp>(
+        op, op.getType(), op.getLhs(), op.getRhs(), op.getWindowStridesAttr(),
+        newPadAttr, op.getLhsDilationAttr(), op.getRhsDilationAttr(),
+        op.getWindowReversalAttr(), op.getDimensionNumbers(),
+        op.getFeatureGroupCount(), op.getBatchGroupCount(),
+        *op.getPrecisionConfig());
+    return success();
+  }
+};
+
+} // namespace
+
+void DynamicConvOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                MLIRContext *context) {
+  results.add<DynamicConvIsConv>(context);
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertOp
 //===----------------------------------------------------------------------===//
 

--- a/mhlo/IR/hlo_ops.td
+++ b/mhlo/IR/hlo_ops.td
@@ -3264,6 +3264,7 @@ def MHLO_DynamicConvOp : MHLO_Op<"dynamic_conv", [Pure]> {
        MHLO_Tensor:$d_padding),
     MHLO_ConvolutionAttributes.attributes);
   let results = (outs MHLO_Tensor);
+  let hasCanonicalizer = 1;
   let hasCustomHLOConverter = 1;
 }
 

--- a/tests/Dialect/mhlo/canonicalize/convolution.mlir
+++ b/tests/Dialect/mhlo/canonicalize/convolution.mlir
@@ -102,3 +102,27 @@ func.func @conv_grouped_is_dot_transpose_out(%arg0: tensor<5x4xf32>, %arg1: tens
   // CHECK: return %[[OUT]]
   return %0 : tensor<6x5xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @dynamic_conv2d_padding
+func.func @dynamic_conv2d_padding(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
+  %pad = arith.constant dense<[2, 0, 1, 1]> : tensor<4xi64>
+  // CHECK: %[[CONV:.+]] = mhlo.convolution
+  // CHECK-SAME: pad = {{\[\[}}2, 0], [1, 1]] 
+  %0 = "mhlo.dynamic_conv"(%arg0, %arg1, %pad) {batch_group_count = 1 : i64,
+    dimension_numbers = #mhlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 4,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 4,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 1,
+      output_feature_dimension = 4,
+      output_spatial_dimensions = [2, 3]
+    >, feature_group_count = 1 : i64, lhs_dilation = dense<1> : tensor<2xi64>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>], rhs_dilation = dense<1> : tensor<2xi64>, window_strides = dense<1> : tensor<2xi64>} :
+       (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>, tensor<4xi64>) -> tensor<32x1x8x8x16xf32>
+  // CHECK: return %[[CONV]]
+  func.return %0 : tensor<32x1x8x8x16xf32>
+}


### PR DESCRIPTION
The case where the padding value is constant for mhlo.convolution can be lowered to mhlo.convolution directly by copying the pad values in.