### PR TITLE
add `MLIRGmlStUtils` as a linked lib in `transforms`

### DIFF
--- a/gml_st/transforms/CMakeLists.txt
+++ b/gml_st/transforms/CMakeLists.txt
@@ -80,6 +80,7 @@ add_mlir_library(GmlStPasses
   MLIRVectorToSCF
   MLIRX86VectorTransforms
   MhloDialect
+  MLIRGmlStUtils
 )
 
 add_mlir_library(GmlStTransforms


### PR DESCRIPTION
fixes https://github.com/tensorflow/mlir-hlo/issues/65